### PR TITLE
Use default value for getting BALANCE_FETCH_TIME from localStorage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "new-tab",
-    "version": "0.1.0",
+    "version": "1.0.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "new-tab",
-            "version": "0.1.0",
+            "version": "1.0.0",
             "dependencies": {
                 "currency-flags": "^2.1.2",
                 "react": "^17.0.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,7 +27,7 @@ export const App: FunctionComponent = () => {
     useEffect(() => {
         const fetchInitialData = async () => {
             const fetchAfterTime = new Date().getTime() - 5 * 60 * 1000; // five minutes ago
-            const balanceFetchTime = Number(getFromLocalStorage(LocalStorageKey.BALANCE_FETCH_TIME));
+            const balanceFetchTime = Number(getFromLocalStorage(LocalStorageKey.BALANCE_FETCH_TIME, "0"));
 
             if (balanceFetchTime === 0 || fetchAfterTime > balanceFetchTime) {
                 try {


### PR DESCRIPTION
Previously, it returned undefined if there was no value present in
localStorage. This was converted to NaN by Number() which the following
lines didn't account for.

This fixes balances not being fetched if opening the project for the
first time.